### PR TITLE
Update JSON gem so it works on newer Rubies

### DIFF
--- a/aptible-toolbelt.gemspec
+++ b/aptible-toolbelt.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gem_config', '0.3.1'
   spec.add_dependency 'git', '1.2.7'
   spec.add_dependency 'i18n', '0.6.11'
-  spec.add_dependency 'json', '1.8.1'
+  spec.add_dependency 'json', '1.8.3'
   spec.add_dependency 'jwt', '0.1.13'
   spec.add_dependency 'mime-types', '1.25.1'
   spec.add_dependency 'minitest', '5.4.0'


### PR DESCRIPTION
Someone in Slack reported the following error installing on Ruby 2.3:

```
$ gem install aptible-toolbelt
Building native extensions.  This could take a while...
ERROR:  Error installing aptible-toolbelt:
    ERROR: Failed to build gem native extension.

    current directory: /usr/local/lib/ruby/gems/2.3.0/gems/json-1.8.1/ext/json/ext/generator
/usr/local/opt/ruby/bin/ruby -r ./siteconf20160224-9144-1oje1t7.rb extconf.rb
creating Makefile

current directory: /usr/local/lib/ruby/gems/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /usr/local/lib/ruby/gems/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:
./../fbuffer/fbuffer.h:175:47: error: too few arguments provided to function-like macro invocation
    VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                              ^
/usr/local/Cellar/ruby/2.3.0/include/ruby-2.3.0/ruby/intern.h:797:9: note: macro 'rb_str_new' defined here
#define rb_str_new(str, len) __extension__ (    \
        ^
In file included from generator.c:1:
./../fbuffer/fbuffer.h:175:11: warning: incompatible pointer to integer conversion initializing 'VALUE' (aka 'unsigned long') with an expression of type 'VALUE (const char *, long)' [-Wint-conversion]
    VALUE result = rb_str_new(FBUFFER_PAIR(fb));
          ^        ~~~~~~~~~~
1 warning and 1 error generated.
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /usr/local/lib/ruby/gems/2.3.0/gems/json-1.8.1 for inspection.
Results logged to /usr/local/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-14/2.3.0/json-1.8.1/gem_make.out
```

I was able to reproduce the issue, and it is fixed by using a newer version of the gem (as per their changelog https://github.com/flori/json/blob/master/CHANGES)